### PR TITLE
Fix user page comments display

### DIFF
--- a/static/scripts/user.js
+++ b/static/scripts/user.js
@@ -5,7 +5,7 @@ console.log("aaa");
 
 let commentsShown = false;
 let postsShown = true;
-defaultDisplay = document.getElementById("commentsContainer").style.display;
+defaultDisplay = document.getElementById("postsContainer").style.display;
 
 function toggleCommentsPosts() {
     // show posts
@@ -17,8 +17,8 @@ function toggleCommentsPosts() {
         commentsShown = false;
         postsShown = true;
 
-        document.getElementById("currentlyDisplaying").innerText = "Showing comments by this user...";
-        document.getElementById("commentPostsButton").innerText = "Show Posts";
+        document.getElementById("currentlyDisplaying").innerText = "Showing posts by this user...";
+        document.getElementById("commentPostsButton").innerText = "Show Comments";
 
         document.getElementById("postsContainer").style.display = defaultDisplay;
         document.getElementById("commentsContainer").style.display = "none";
@@ -31,8 +31,8 @@ function toggleCommentsPosts() {
         }
         commentsShown = true;
         postsShown = false;
-        document.getElementById("currentlyDisplaying").innerText = "Showing posts by this user...";
-        document.getElementById("commentPostsButton").innerText = "Show Comments";
+        document.getElementById("currentlyDisplaying").innerText = "Showing comments by this user...";
+        document.getElementById("commentPostsButton").innerText = "Show Post";
         document.getElementById("postsContainer").style.display = "none";
         document.getElementById("commentsContainer").style.display = defaultDisplay;
     }

--- a/templates/user.html
+++ b/templates/user.html
@@ -28,7 +28,7 @@
 
         <!-- Add functionality to load posts and comments based on button press. -->
         <div id="postsContainer" onload="populateProfilePosts"></div>
-        <div id="commentsContainer"></div>
+        <div id="commentsContainer" style="display:none"></div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
User page was showing both posts and comments.

- Fixed initial display to only show one
- Fixed button which was showing the opposite of what it was supposed to
![images](https://github.com/Septillion24/itsc-3155-final-project/assets/34352230/fc0dd693-83e2-4438-af48-4c3357d4fc44)
